### PR TITLE
feat: iframe 크기 변화에 따라 height 변경 (related to: #4)

### DIFF
--- a/pages/detail.tsx
+++ b/pages/detail.tsx
@@ -2,20 +2,51 @@ import Seo from '@/components/Seo';
 import Rooms from '@/components/detail/Rooms/Index';
 import TopInfo from '@/components/detail/Top/Index';
 import Image from 'next/image';
-import React from 'react';
+import React, { useEffect } from 'react';
 
 type Props = {};
 
 export default function Detail({}: Props) {
-  const nums = [2, 3, 4, 5, 6, 7];
+  const iframeRef = React.useRef<HTMLIFrameElement | null>(null);
+
+  React.useEffect(() => {
+    const iframe = iframeRef.current;
+    if (!iframe) return undefined;
+
+    const listener = (e: MessageEvent) => {
+      if (!e.data.type) return;
+      if (e.data.type === 'height') {
+        console.log('자식으로 부터 온 height', e.data.message);
+        iframe.style.height = `${e.data.message}px`;
+      }
+    };
+
+    window.addEventListener('message', listener);
+
+    if (iframe && iframe.contentWindow) {
+      iframe.contentWindow?.postMessage(
+        { type: 'loaded', message: 'on loaded!' },
+        '*'
+      );
+    }
+
+    return () => {
+      window.removeEventListener('message', listener);
+    };
+  }, []);
+
   return (
     <div className='h-full'>
       <Seo title='ReviewMate | Home' />
       <TopInfo />
       <Rooms />
       <iframe
-        src='https://main.d33vkfpm9flfhs.amplifyapp.com/review/list'
-        className='w-full h-full overflow-y-hidden'
+        ref={iframeRef}
+        src='http://localhost:3001/review/list'
+        height='0'
+        width='100%'
+        name='review-mate-product-reviews'
+        className='w-full'
       />
     </div>
   );


### PR DESCRIPTION
### 관련 이슈
#4 

### 작업 사항
- 리뷰 위젯 iframe 삽입 완료 (iframe의 변하는 height 이슈 해결)
- iframe과의 데이터 전송 프로세스 구현

### 특이사항
> 1. 자식이 load되면 자식으로부터 height를 전달해달라는 의미로 load 메세지를 전송함
-> 해당 메세지를 받은 자식은 자신의 height를 부모로 전송함, 해당 height를 iframe 높이로 업데이트
-> 자식이 load되기 전에는 자식으로부터 온 메세지를 받을 수 없기 때문에, 자식이 load된 후에 메세지를 보내달라는 의미로 전송하는 것이다.
>
> 2. iframe의 크기가 변화될 때 마다 그로부터 오는 메세지의 height 값으로 height를 변경함