### PR TITLE
fix: 배포시 이미지 나오지 않는 에러 수정시도3 - alias paths 변경

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,7 @@
     "incremental": true,
     "baseUrl": ".",
     "paths": {
-      "@/*": ["./*"]
+      "@/*": ["/*"]
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],


### PR DESCRIPTION
#14 #15 에서 버그 fix시도 실패 후 3번째 시도

## 버그 설명
next/image를 사용한 이미지가 배포버전에서 로드되지 않는 현상 발생

## 해결시도
tsconfig 설정에서 alias의 paths 변경