### PR TITLE
fix: 배포시 이미지 나오지 않는 에러 수정시도5(해결) - next/image unoptimized

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,9 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
-}
+  images: {
+    unoptimized: true,
+  },
+};
 
-module.exports = nextConfig
+module.exports = nextConfig;


### PR DESCRIPTION
#14 #15 #16 에서 버그 fix 시도 실패 후 5번째 시도

## 버그 설명
next/image를 사용한 이미지가 배포버전에서 로드되지 않는 현상 발생

## 해결완료
amplify에서 next/image의 최적화를 지원하지 않는 이슈가 있었음
이에 따라 next/image의 image optimazaion 비활성화
참고 -> https://docs.amplify.aws/guides/hosting/nextjs/q/platform/js/#adding-amplify-hosting

## 특이사항
웹페이지에 이미지가 많아서 이미지 최적화가 필요하다고 생각합니다.
특히 next/image의 placeholder등의 기능이 유용하다고 생각했는데, amplify에서 지원을 안하는 관계로 사용을 할 수 없게 되었습니다.
따라서 일단 우선순위가 높은 기능들을 먼저 완성한 후에 amplify를 사용하지 않고 직접 다시 배포할 계획입니다.