### PR TITLE
fix: constant.tsx를 ignore해서 생긴 에러 해결

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,4 @@ yarn-error.log*
 *.tsbuildinfo
 next-env.d.ts
 
-
-/config/
 api.tsx

--- a/config/constant.tsx
+++ b/config/constant.tsx
@@ -1,0 +1,8 @@
+// 데모 리뷰 조회용 상품 id
+export const PRODUCT_ID = 'PRODUCT-0001';
+
+// 리뷰메이트 서비스를 사용하는 파트너사 도메인
+export const PARTNER_DOMAIN = 'goodchoice.kr';
+
+// 데모를 위한 리뷰메이트 서비스 API URL
+export const REVIEW_MATE_URL = 'http://test.api.reviewmate.co.kr:8080';

--- a/state/reservationState.tsx
+++ b/state/reservationState.tsx
@@ -1,6 +1,0 @@
-import { atom } from 'recoil';
-
-export const reservationIdState = atom({
-  key: 'reservationIdState', 
-  default: '', 
-});


### PR DESCRIPTION
## 버그 설명
constant.tsx를 ignore해서 깃허브와 연동된 amplify에서 해당 파일을 찾지 못해서 에러 발생

## 접근 방법
constant.tsx ignore제거

### 첨부
> <img width="1230" alt="image" src="https://github.com/review-mate/review-mate-landing-page/assets/65444249/c1e71f32-4abd-4cff-8764-f85d5832f091">

### 특이사항
> 추가로 삭제한 recoil 관련 코드가 남아있는 것을 발견하여 제거함
