### PR TITLE
fix: (차단됨:mixed-content) 에러 해결

### DIFF
--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -3,7 +3,12 @@ import { Html, Head, Main, NextScript } from 'next/document';
 export default function Document() {
   return (
     <Html>
-      <Head />
+      <Head>
+        <meta
+          httpEquiv='Content-Security-Policy'
+          content='upgrade-insecure-requests'
+        />
+      </Head>
       <meta charSet='utf-8'></meta>
       <body>
         <Main />


### PR DESCRIPTION
## 버그 설명
배포 환경에서 api 요청 시 (차단됨:mixed-content) error가 발생함

## 접근 방법
검색 결과 암호화된 HTTPS 페이지에 암호화되지 않은 HTTP를 통해 요청할 때 발생하는 에러라고 한다.
현재 reviewmate.co.kr 사이트는 https지만 요청을 보내는 서버의 주소는 http로 이루어져 있기 때문에 발생하는 듯 하다.
지금 당장 https로 서버를 만들기는 힘드므로 프론트에서 해당 에러를 제거하기 위해 pages/_document.tsx에 아래와 같은 메타태그를 추가했다.
<meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests" />

## 관련 사진 첨부
<img width="563" alt="image" src="https://github.com/review-mate/review-mate-landing-page/assets/65444249/2b4b4fb2-1471-4531-ac69-15222699d3e6">