### PR TITLE
design: 세부 디자인 및 반응형 디자인 fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ yarn-error.log*
 next-env.d.ts
 
 api.tsx
+
+.env

--- a/components/NavBar.tsx
+++ b/components/NavBar.tsx
@@ -4,19 +4,17 @@ import React from 'react';
 import logo from '@/public/images/logo.svg';
 import user from '@/public/images/user.svg';
 
-type Props = {};
-
-export default function NavBar({}: Props) {
+export default function NavBar() {
   return (
     <nav className='h-[70px] flex items-center justify-between mb-12'>
       <Link href='/'>
         <Image src={logo} alt='로고' width={115} height={40} />
       </Link>
-      <div className='w-3/5 flex gap-16'>
-        <div className='w-25'>
+      <div className='w-3/5 flex'>
+        <div className='w-23 md:w-25 mr-[10%]'>
           <Link href='/demo/product'>리뷰 목록 체험</Link>
         </div>
-        <div className='w-25'>
+        <div className='w-23 md:w-25'>
           <Link href='/demo/beforeReview'>리뷰 작성 체험</Link>
         </div>
       </div>

--- a/components/detail/Rooms/Index.tsx
+++ b/components/detail/Rooms/Index.tsx
@@ -7,7 +7,7 @@ type Props = {};
 
 export default function Rooms({}: Props) {
   return (
-    <div className='flex flex-col'>
+    <div className='flex flex-col mt-20 mb-20'>
       <div className='text-body1 font-bold mb-6'>객실 종류 8개</div>
       <Room />
       <Room />

--- a/components/detail/Rooms/Index.tsx
+++ b/components/detail/Rooms/Index.tsx
@@ -21,14 +21,16 @@ const Room = () => {
   return (
     <React.Fragment>
       <div className='flex flex-row'>
+        <div className='w-2/6 lg:w-1/5'>
         <Image
           src={room}
           alt='객실'
           placeholder='blur'
           width={250}
           height={180}
+          layout='responsive'
           objectFit='contain'
-        />
+        /></div>
         <div className='flex flex-1 flex-col ml-5'>
           <div className='text-subTitle font-mid mb-2'>스탠다드 더블룸</div>
           <div className='flex justify-between'>
@@ -48,7 +50,7 @@ const Room = () => {
               </ul>
             </div>
             <div className='flex flex-col md:flex-row items-center'>
-              <div className='flex mr-7'>
+              <div className='flex mr-7 mb-5 md:mb-0'>
                 <div className='text-num3 font-bold mr-1'>127,000</div>
                 <div className='text-num3 font-mid'>원</div>
               </div>

--- a/components/detail/Top/Index.tsx
+++ b/components/detail/Top/Index.tsx
@@ -20,18 +20,18 @@ export default function TopInfo() {
         <div className='mr-[10px] font-bold'>5.0</div>
         <div className='text-gray02'>1성급</div>
       </div>
-      <div className='grid grid-cols-2 gap-4 mb-8'>
+      <div className='grid grid-cols-1 md:grid-cols-2 gap-4 mb-8'>
         <LeftInfo />
         <RightInfo />
       </div>
-      <div className='grid grid-cols-2 gap-4'>
+      <div className='grid grid-cols-1 md:grid-cols-2 gap-4'>
         <div />
-        <div className='flex flex-col md:flex-row justify-between'>
+        <div className='flex flex-row justify-between'>
           <div className='flex'>
             <div className='flex justify-center items-center mr-2.5 w-[50px] h-[50px] bg-gray07 rounded'>
               <Image src={heart} alt='찜하기' width={24} />
             </div>
-            <div className='flex justify-center items-center w-[143px] h-[50px] bg-black text-white rounded'>
+            <div className='flex justify-center items-center mr-2.5 w-[143px] h-[50px] bg-black text-white rounded'>
               객실선택
             </div>
           </div>

--- a/components/detail/Top/LeftInfo.tsx
+++ b/components/detail/Top/LeftInfo.tsx
@@ -12,11 +12,11 @@ export default function LeftInfo() {
   const hotelImgs = [hotel2, hotel3, hotel4, hotel5, hotel6, hotel7];
   return (
     <div>
-      <div className='grid grid-rows-5 grid-cols-6 gap-1'>
+      <div className='grid grid-cols-6 lg:grid-cols-6 gap-1 mb-7 md:mb-0'>
         <Image
-          className='w-full row-span-4 col-span-6'
+          className='w-full col-span-6 lg:col-span-6'
           src={hotel1}
-          alt='hotel1'
+          alt='호텔사진1'
           placeholder='blur'
           width={535}
           height={374}
@@ -25,9 +25,9 @@ export default function LeftInfo() {
         {hotelImgs.map((hotel, index) => (
           <Image
             key={index}
-            className='w-full round-10 flex flex-1'
+            className='w-full col-span-1 rounded flex flex-1'
             src={hotel}
-            alt='hotel2'
+            alt={`호텔사진${index + 1}`}
             placeholder='blur'
             width={85}
             height={85}

--- a/components/detail/Top/RightInfo.tsx
+++ b/components/detail/Top/RightInfo.tsx
@@ -39,15 +39,25 @@ interface TagBoxProps {
 
 const TagBox = ({ color, title }: TagBoxProps) => {
   const tags = ['청결', '위치', '서비스', '가격', '편의시설', '안전'];
+
+  const tagBasicStyle = 'py-1 px-2.5 bg-white rounded text-body3 font-mid';
+  const tagColorStyle =
+    color === 'blue'
+      ? `${tagBasicStyle} border border-blue text-blue`
+      : `${tagBasicStyle} border border-red text-red`;
+
+  const titleBasicStyle = 'mb-2.5 text-body1 font-bold';
+  const titleColorStyle =
+    color === 'blue'
+      ? `${titleBasicStyle} text-blue`
+      : `${titleBasicStyle} text-red`;
+
   return (
     <div className='flex flex-col justify-center p-5 mt-1 bg-gray08 rounded-[10px]'>
-      <div className={`mb-2.5 text-${color} text-body1 font-bold`}>{title}</div>
+      <div className={titleColorStyle}>{title}</div>
       <div className='flex flex-wrap gap-1'>
         {tags.map((tag, index) => (
-          <div
-            key={index}
-            className={`py-1 px-2.5 bg-white rounded border border-${color} text-body3 font-mid text-${color}`}
-          >
+          <div key={index} className={tagColorStyle}>
             {tag}
           </div>
         ))}

--- a/config/api.tsx
+++ b/config/api.tsx
@@ -1,7 +1,7 @@
 const WIDGET_DEV_API = 'http://localhost:3001';
-const WIDGET_PROD_API = 'https://widget.reviewmate.co.kr';
+const WIDGET_PROD_API = process.env.REACT_APP_BASE_URL;
 
-// let mode = 'dev';
-let mode = 'prod'
+let mode = 'dev';
+// let mode = 'prod'
 
 export const WIDGET_API = mode === 'prod' ? WIDGET_PROD_API : WIDGET_DEV_API;

--- a/config/api.tsx
+++ b/config/api.tsx
@@ -1,7 +1,7 @@
 const WIDGET_DEV_API = 'http://localhost:3001';
 const WIDGET_PROD_API = process.env.REACT_APP_BASE_URL;
 
-let mode = 'dev';
-// let mode = 'prod'
+// let mode = 'dev';
+let mode = 'prod'
 
 export const WIDGET_API = mode === 'prod' ? WIDGET_PROD_API : WIDGET_DEV_API;

--- a/config/constant.tsx
+++ b/config/constant.tsx
@@ -1,8 +1,8 @@
 // 데모 리뷰 조회용 상품 id
-export const PRODUCT_ID = 'PRODUCT-0001';
+export const PRODUCT_ID = process.env.NEXT_PUBLIC_PRODUCT_ID;
 
 // 리뷰메이트 서비스를 사용하는 파트너사 도메인
-export const PARTNER_DOMAIN = 'goodchoice.kr';
+export const PARTNER_DOMAIN = process.env.NEXT_PUBLIC_PARTNER_DOMAIN;
 
 // 데모를 위한 리뷰메이트 서비스 API URL
-export const REVIEW_MATE_URL = 'http://test.api.reviewmate.co.kr:8080';
+export const REVIEW_MATE_URL = process.env.NEXT_PUBLIC_BASE_URL;

--- a/hooks/useChildHeight.tsx
+++ b/hooks/useChildHeight.tsx
@@ -12,7 +12,6 @@ export default function useChildHeight(): {
     const listener = (e: MessageEvent) => {
       if (!e.data.type) return;
       if (e.data.type === 'height') {
-        console.log('자식으로 부터 온 height', e.data.message);
         iframe.style.height = `${e.data.message}px`;
       }
     };

--- a/pages/demo/beforeReview.tsx
+++ b/pages/demo/beforeReview.tsx
@@ -51,7 +51,6 @@ export default function BeforeReview() {
       'singleTravelReservationCreateRequest',
       new Blob([JSON.stringify(data)], { type: 'application/json' })
     );
-    console.log('예약데이터', data);
 
     // 데모를 위한 예약 API일 뿐, 실제 파트너사에서는 리뷰메이트 api를 사용하지 않습니다.
     try {
@@ -59,14 +58,12 @@ export default function BeforeReview() {
         `${REVIEW_MATE_URL}/api/client/v1/${PARTNER_DOMAIN}/products/travel/single/reservations`,
         reservationData
       );
-      console.log('예약성공', response.data);
       router.push({
         pathname: `/demo/review/write`,
         query: { reservationId: reservationId },
       });
     } catch (error) {
       alert('예약에 실패했습니다. 다시 시도해주세요.');
-      console.log('예약실패', error);
     }
 
     return reservationId;

--- a/pages/demo/product.tsx
+++ b/pages/demo/product.tsx
@@ -2,7 +2,7 @@ import Seo from '@/components/Seo';
 import Rooms from '@/components/detail/Rooms/Index';
 import TopInfo from '@/components/detail/Top/Index';
 import { WIDGET_API } from '@/config/api';
-import { PRODUCT_ID } from '@/config/constant';
+import { PARTNER_DOMAIN, PRODUCT_ID } from '@/config/constant';
 import useChildHeight from '@/hooks/useChildHeight';
 import React, { useEffect } from 'react';
 
@@ -18,7 +18,7 @@ export default function Product({}: Props) {
       <Rooms />
       <iframe
         ref={iframeRef}
-        src={`${WIDGET_API}/review/list?product_id=${PRODUCT_ID}`}
+        src={`${WIDGET_API}/review/list?partner_domain=${PARTNER_DOMAIN}&product_id=${PRODUCT_ID}`}
         height='0'
         width='100%'
         name='review-mate-product-reviews'

--- a/pages/demo/review/write.tsx
+++ b/pages/demo/review/write.tsx
@@ -1,6 +1,7 @@
 import Seo from '@/components/Seo';
 import WritePageTopInfo from '@/components/write/Top';
 import { WIDGET_API } from '@/config/api';
+import { PARTNER_DOMAIN } from '@/config/constant';
 import useChildHeight from '@/hooks/useChildHeight';
 import useChildMessage from '@/hooks/useChildMessage';
 import { useRouter } from 'next/router';
@@ -14,7 +15,6 @@ export default function WritePage() {
   const reservationId = router.query.reservationId;
 
   useEffect(() => {
-    console.log(message);
     if (message === 'success') {
       router.push('/demo/product');
     }
@@ -27,7 +27,7 @@ export default function WritePage() {
       <WritePageTopInfo />
       <iframe
         ref={iframeRef}
-        src={`${WIDGET_API}/review/write?reservation_id=${reservationId}`}
+        src={`${WIDGET_API}/review/write?partner_domain=${PARTNER_DOMAIN}&reservation_id=${reservationId}`}
         className='w-full'
       />
     </div>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -14,14 +14,15 @@ export default function Home() {
   }, []);
 
   return (
-    <main className='flex flex-col lg:flex-row justify-center lg:justify-between items-center pt-12'>
+    <main className='flex w-full flex-col lg:flex-row justify-center lg:justify-between items-center pt-12'>
       <Seo title='ReviewMate|Home' />
-      <div className='flex flex-col items-center lg:items-start lg:w-1/2 animate-appear1 w-auto mb-10 lg:mb-0'>
-        <h1 className='text-5xl font-bold mb-5 inline-block'>여행사의</h1>
-        <h1 className='text-5xl font-bold mb-10 inline-block'>
-          구매 전환율 상승 파트너
-        </h1>
-        <h3 className='text-body1 mb-14 w-1/2 inline-block'>
+      <div className='flex flex-col items-center lg:items-start w-auto lg:w-1/2 animate-appear1 mb-10 lg:mb-0'>
+        <h1 className='text-5xl font-bold mb-5'>여행사의</h1>
+        <div className='flex flex-wrap justify-center lg:justify-start'>
+          <h1 className='text-5xl font-bold mb-5'>구매 전환율 상승</h1>
+          <h1 className='text-5xl font-bold mb-10'>파트너</h1>
+        </div>
+        <h3 className='text-body1 mb-14 w-[300px] text-center lg:text-start'>
           리뷰메이트는 고객의 리뷰를 통해 여행 상품의 구매 전환율을 상승시키는
           리뷰 통합 관리 플랫폼입니다.
         </h3>
@@ -37,7 +38,7 @@ export default function Home() {
           colorBlue={false}
         />
       </div>
-      <div className='w-[550px] animate-appear1 flex justify-end pb-10 lg:pb-0'>
+      <div className='w-full md:w-[550px] animate-appear1 flex justify-center lg:justify-end pb-10 lg:pb-0'>
         <Image
           src='/images/landing.png'
           alt='리뷰메이트 소개 이미지'

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -10,7 +10,6 @@ export default function Home() {
   useEffect(() => {
     const token = localStorage.getItem('loginToken');
     setLoginToken(token);
-    console.log('token', token);
   }, []);
 
   return (


### PR DESCRIPTION
### 관련 이슈
#3 #8 #11 

### 작업 사항
- 기존 상세페이지의 상단 태그 부분 색상 적용 안되던 부분 코드 교체로 해결
- 랜딩페이지 및 상세페이지 반응형 업그레이드

### 첨부
> <img width="1678" alt="image" src="https://github.com/review-mate/review-mate-landing-page/assets/65444249/919ada11-cd5b-4b47-b08f-ce29544fea8d">
> <img width="300" alt="image" src="https://github.com/review-mate/review-mate-landing-page/assets/65444249/17fc970d-5d69-439e-96ed-994d8235baf8">


> <img width="1671" alt="image" src="https://github.com/review-mate/review-mate-landing-page/assets/65444249/59a78c4a-511c-4dd4-85e5-e5705de96aa5">
> <img width="300" alt="image" src="https://github.com/review-mate/review-mate-landing-page/assets/65444249/a0ba7521-7263-4e3a-b515-0466b77d8182">


### 특이사항
> 아직 모바일 반응형은 작업하지 않은 상태, 추후 작업할 예정
> 기존 상세페이지의 상단 태그 부분 색상은 tailwind의 잘못된 재사용 문법으로 인한 오류였음
