### PR TITLE
fix: 위젯 url과 실제 서버 api가 혼동되어 발생한 에러 해결

### DIFF
--- a/config/api.tsx
+++ b/config/api.tsx
@@ -1,7 +1,9 @@
-const WIDGET_DEV_API = 'http://localhost:3001';
-const WIDGET_PROD_API = process.env.REACT_APP_BASE_URL;
+import { WIDGET_URL } from './constant';
 
-// let mode = 'dev';
-let mode = 'prod'
+const WIDGET_DEV_API = 'http://localhost:3001';
+const WIDGET_PROD_API = WIDGET_URL;
+
+let mode = 'dev';
+// let mode = 'prod';
 
 export const WIDGET_API = mode === 'prod' ? WIDGET_PROD_API : WIDGET_DEV_API;

--- a/config/constant.tsx
+++ b/config/constant.tsx
@@ -6,3 +6,7 @@ export const PARTNER_DOMAIN = process.env.NEXT_PUBLIC_PARTNER_DOMAIN;
 
 // 데모를 위한 리뷰메이트 서비스 API URL
 export const REVIEW_MATE_URL = process.env.NEXT_PUBLIC_BASE_URL;
+
+// 리뷰메이트 위젯  URL
+export const WIDGET_URL = process.env.NEXT_PUBLIC_WIDGET_URL;
+


### PR DESCRIPTION
## 버그 설명
위젯 url와 실제 서버 api가 혼동되어 에러 발생

## 접근 방법
각각 알맞은 api로 변경
상품 예약 -> 서버 api
그 외 -> 위젯 url