### PR TITLE
fix: 예약페이지에 주소로 접근 시 '잘못된 접근입니다'에러 뜨는 현상 fix

### DIFF
--- a/components/detail/Top/Index.tsx
+++ b/components/detail/Top/Index.tsx
@@ -25,7 +25,6 @@ export default function TopInfo() {
     async function fetchData() {
       const data = await fetchProductData(productId); // userId를 원하는 값으로 수정
       setProductData(data);
-      console.log(data);
     }
 
     fetchData();

--- a/components/detail/Top/RightInfo.tsx
+++ b/components/detail/Top/RightInfo.tsx
@@ -15,7 +15,6 @@ interface Props {
 }
 
 export default function RightInfo({ positiveTags, negativeTags }: Props) {
-  console.log(positiveTags, negativeTags);
   return (
     <div>
       <div className='flex flex-col justify-end h-full'>

--- a/context/LoginContext.tsx
+++ b/context/LoginContext.tsx
@@ -9,19 +9,19 @@ import {
 } from 'react';
 
 interface LoginContextType {
-  isLogin: boolean;
-  setIsLogin: Dispatch<SetStateAction<boolean>>;
+  isLogin: boolean | undefined;
+  setIsLogin: Dispatch<SetStateAction<boolean | undefined>>;
 }
 
 const LoginContext = createContext<LoginContextType>({
-  isLogin: false,
+  isLogin: undefined,
   setIsLogin: () => {},
 });
 
 export const useLoginContext = () => useContext(LoginContext);
 
 export const LoginProvider = ({ children }: { children: ReactNode }) => {
-  const [isLogin, setIsLogin] = useState(false);
+  const [isLogin, setIsLogin] = useState<boolean | undefined>(undefined);
 
   useEffect(() => {
     const token = localStorage.getItem('loginToken');

--- a/hooks/useLogin.tsx
+++ b/hooks/useLogin.tsx
@@ -4,10 +4,6 @@ import { use, useEffect } from 'react';
 
 export const useLogin = () => {
   const { setIsLogin, isLogin } = useLoginContext();
-  useEffect(() => {
-    console.log('로긴', isLogin);
-  }, [isLogin]);
-
   const login = (
     name: string,
     phoneNum: string,

--- a/pages/demo/reservation.tsx
+++ b/pages/demo/reservation.tsx
@@ -21,7 +21,7 @@ export default function Reservation() {
     } else {
       startReservation();
     }
-  }, [router.isReady, router.query.destination]);
+  }, [router.isReady, destination]);
 
   const handleInvalidAccess = () => {
     alert('잘못된 접근입니다.');

--- a/pages/demo/reservation.tsx
+++ b/pages/demo/reservation.tsx
@@ -17,7 +17,6 @@ export default function Reservation() {
     if (router.isReady && destination === undefined) {
       alert('잘못된 접근입니다.');
       router.push('/');
-      console.log(destination, 'destination');
     } else if (isLogin !== undefined && !isLogin) {
       alert('로그인 후 이용 가능합니다.');
       router.push({

--- a/pages/demo/reservation.tsx
+++ b/pages/demo/reservation.tsx
@@ -9,14 +9,16 @@ import { useLoginContext } from 'context/LoginContext';
 export default function Reservation() {
   const router = useRouter();
   const destination = router.query.destination;
+  console.log(router);
 
   const { isLogin } = useLoginContext();
 
   useEffect(() => {
-    if (destination === undefined) {
+    if (router.isReady && destination === undefined) {
       alert('잘못된 접근입니다.');
       router.push('/');
-    } else if (!isLogin) {
+      console.log(destination, 'destination');
+    } else if (isLogin !== undefined && !isLogin) {
       alert('로그인 후 이용 가능합니다.');
       router.push({
         pathname: '/login',
@@ -25,7 +27,7 @@ export default function Reservation() {
     } else {
       startReservation();
     }
-  }, []);
+  }, [router.isReady, router.query.destination]);
 
   const startReservation = async () => {
     // 상품구매(예약)는 데모를 위해 임시로 만들어둔 기능이기 때문에, 예약id를 랜덤으로 생성합니다.
@@ -33,10 +35,10 @@ export default function Reservation() {
       const reservationId = getTempReservationId();
       makeReservation(reservationId);
       destination &&
-      router.push({
-        pathname: destination.toString(),
-        query: { reservationId: reservationId },
-      });
+        router.push({
+          pathname: destination.toString(),
+          query: { reservationId: reservationId },
+        });
     }, 700);
   };
 

--- a/pages/demo/reservation.tsx
+++ b/pages/demo/reservation.tsx
@@ -15,18 +15,26 @@ export default function Reservation() {
 
   useEffect(() => {
     if (router.isReady && destination === undefined) {
-      alert('잘못된 접근입니다.');
-      router.push('/');
+      handleInvalidAccess();
     } else if (isLogin !== undefined && !isLogin) {
-      alert('로그인 후 이용 가능합니다.');
-      router.push({
-        pathname: '/login',
-        query: { destination: destination, route: '/demo/reservation' },
-      });
+      handleLoginRequired();
     } else {
       startReservation();
     }
   }, [router.isReady, router.query.destination]);
+
+  const handleInvalidAccess = () => {
+    alert('잘못된 접근입니다.');
+    router.push('/');
+  };
+
+  const handleLoginRequired = () => {
+    alert('로그인 후 이용 가능합니다.');
+    router.push({
+      pathname: '/login',
+      query: { destination: destination, route: '/demo/reservation' },
+    });
+  };
 
   const startReservation = async () => {
     // 상품구매(예약)는 데모를 위해 임시로 만들어둔 기능이기 때문에, 예약id를 랜덤으로 생성합니다.


### PR DESCRIPTION
### 관련 이슈
#44 

### 작업 사항
- 챗봇에서 리뷰 작성 페이지 접속을 위해 예약페이지 링크 접속시 '잘못된 접근입니다' 에러 뜨는 현상 수정

### 상세설명
> 1. 예약페이지는 '리뷰 작성'과 같이 예약이 필요한 페이지로 리다이렉트 하는게 목적이기 때문에, 기존에 destination이 없다면 '잘못된 접근입니다' 알림으로 예외처리 함
-> 사이트 내에서는 잘 동작하는데, 링크로 접속할 경우, router.query가 준비되지 않은 상태에서 destination이 없다고 판단해서 에러 발생
-> router.isReady를 이용해서 query가 준비 된 후 destination 확인하는 방식으로 해결

> 2. 그 다음으로 로그인이 안돼있을 경우 '로그인 후 이용 가능합니다.'로 예외처리 함
-> 마찬가지로 로그인 여부를 판단하기 전에  기본 값인 false로 로그인이 안돼있다고 처리 해버리는 현상 발생
-> login 기본 값을 Undefined로 교체 후, login 값이 업데이트 될 때 확인하는 방식으로 해결
