### PR TITLE
[빌드29]fix: 빌드 에러 import 수정

### DIFF
--- a/pages/demo/post-trip/beforeReview.tsx
+++ b/pages/demo/post-trip/beforeReview.tsx
@@ -1,5 +1,5 @@
 import Seo from '@/components/Seo';
-import { BlackButton } from '@/components/global/button/BasicButton';
+import { BlackButton } from '@/components/global/button/BlackButton';
 import WritePageTopInfo from '@/components/write/Top';
 import { useRouter } from 'next/router';
 import React from 'react';


### PR DESCRIPTION
### 관련 빌드
#58 

### 상세 설명
- button 컴포넌트를 분할하면서 import 주소가 변경이 반영 안돼서 에러 발생

### 첨부
>  <img width="1227" alt="image" src="https://github.com/review-mate/review-mate-landing-page/assets/65444249/6417e4e2-4a32-4dd0-8726-50ffb0528246">